### PR TITLE
facedetect.py: bad relative path for haarcascade classifier config file.

### DIFF
--- a/engine/src/facedetect.py
+++ b/engine/src/facedetect.py
@@ -6,7 +6,7 @@ Exposes a FaceDetect class which expects an image as argument.
 
 import cv2
 
-HAAR_CASC = "haarcascade_frontalface_alt.xml"
+HAAR_CASC = "/../lib/haarcascade_frontalface_alt.xml"
 
 
 class FaceDetect:


### PR DESCRIPTION
Simple bugfix which prevents the application to run, needed to be pushed asap.